### PR TITLE
Add medical test price comparison feature with mock provider data

### DIFF
--- a/Tailspin.SpaceGame.Web/Controllers/MedicalTestController.cs
+++ b/Tailspin.SpaceGame.Web/Controllers/MedicalTestController.cs
@@ -1,0 +1,54 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using TailSpin.SpaceGame.Web.Models.MedicalTest;
+using TailSpin.SpaceGame.Web.Services;
+
+namespace TailSpin.SpaceGame.Web.Controllers
+{
+    public class MedicalTestController : Controller
+    {
+        private readonly TestPriceComparisonService _comparisonService;
+
+        public MedicalTestController(TestPriceComparisonService comparisonService)
+        {
+            _comparisonService = comparisonService;
+        }
+
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return View(new TestSearchQuery());
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Compare(TestSearchQuery query)
+        {
+            if (string.IsNullOrWhiteSpace(query.TestNames))
+            {
+                ModelState.AddModelError("TestNames", "Please enter at least one test name.");
+                return View("Index", query);
+            }
+
+            if (string.IsNullOrWhiteSpace(query.Location))
+            {
+                ModelState.AddModelError("Location", "Please enter your city.");
+                return View("Index", query);
+            }
+
+            var result = await _comparisonService.CompareAsync(query);
+            return View("Results", result);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Compare(string testNames, string location)
+        {
+            if (string.IsNullOrWhiteSpace(testNames) || string.IsNullOrWhiteSpace(location))
+                return RedirectToAction("Index");
+
+            var query = new TestSearchQuery { TestNames = testNames, Location = location };
+            var result = await _comparisonService.CompareAsync(query);
+            return View("Results", result);
+        }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Models/MedicalTest/ComparisonViewModel.cs
+++ b/Tailspin.SpaceGame.Web/Models/MedicalTest/ComparisonViewModel.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TailSpin.SpaceGame.Web.Models.MedicalTest
+{
+    public class ComparisonViewModel
+    {
+        public TestSearchQuery Query { get; set; }
+        public List<TestComparisonRow> Results { get; set; } = new List<TestComparisonRow>();
+        public List<string> ProviderNames { get; set; } = new List<string>();
+        public bool HasResults => Results != null && Results.Any();
+
+        public decimal TotalSavings
+        {
+            get
+            {
+                if (!HasResults) return 0;
+                decimal maxTotal = Results.Sum(r =>
+                    r.ProviderPrices.Where(p => p.IsAvailable).Select(p => p.Price).DefaultIfEmpty(0).Max());
+                decimal minTotal = Results.Sum(r =>
+                    r.CheapestProvider?.Price ?? 0);
+                return maxTotal - minTotal;
+            }
+        }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Models/MedicalTest/TestComparisonRow.cs
+++ b/Tailspin.SpaceGame.Web/Models/MedicalTest/TestComparisonRow.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TailSpin.SpaceGame.Web.Models.MedicalTest
+{
+    public class TestComparisonRow
+    {
+        public string TestName { get; set; }
+        public List<TestPriceResult> ProviderPrices { get; set; } = new List<TestPriceResult>();
+
+        public TestPriceResult CheapestProvider =>
+            ProviderPrices
+                .Where(p => p.IsAvailable)
+                .OrderBy(p => p.Price)
+                .FirstOrDefault();
+    }
+}

--- a/Tailspin.SpaceGame.Web/Models/MedicalTest/TestPriceResult.cs
+++ b/Tailspin.SpaceGame.Web/Models/MedicalTest/TestPriceResult.cs
@@ -1,0 +1,11 @@
+namespace TailSpin.SpaceGame.Web.Models.MedicalTest
+{
+    public class TestPriceResult
+    {
+        public string TestName { get; set; }
+        public string ProviderName { get; set; }
+        public decimal Price { get; set; }
+        public bool IsAvailable { get; set; }
+        public string BookingUrl { get; set; }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Models/MedicalTest/TestSearchQuery.cs
+++ b/Tailspin.SpaceGame.Web/Models/MedicalTest/TestSearchQuery.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TailSpin.SpaceGame.Web.Models.MedicalTest
+{
+    public class TestSearchQuery
+    {
+        public string TestNames { get; set; }
+        public string Location { get; set; }
+
+        public List<string> ParsedTestNames =>
+            TestNames?.Split(',')
+                .Select(t => t.Trim())
+                .Where(t => !string.IsNullOrEmpty(t))
+                .ToList()
+            ?? new List<string>();
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/ILabTestPriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/ILabTestPriceProvider.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TailSpin.SpaceGame.Web.Models.MedicalTest;
+
+namespace TailSpin.SpaceGame.Web.Services
+{
+    public interface ILabTestPriceProvider
+    {
+        string ProviderName { get; }
+        Task<List<TestPriceResult>> GetPricesAsync(List<string> testNames, string location);
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/MockPriceData.cs
+++ b/Tailspin.SpaceGame.Web/Services/MockPriceData.cs
@@ -1,0 +1,336 @@
+using System.Collections.Generic;
+
+namespace TailSpin.SpaceGame.Web.Services
+{
+    public static class MockPriceData
+    {
+        // Base prices per test per provider (in INR)
+        // Format: TestName -> ProviderName -> Price
+        public static readonly Dictionary<string, Dictionary<string, decimal>> BasePrices =
+            new Dictionary<string, Dictionary<string, decimal>>
+            {
+                ["Complete Blood Count"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 199, ["PharmEasy"] = 219, ["Orange Health"] = 249, ["Apollo 24*7"] = 279
+                },
+                ["Lipid Profile"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 549, ["PharmEasy"] = 539, ["Orange Health"] = 599, ["Apollo 24*7"] = 649
+                },
+                ["Thyroid Stimulating Hormone"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 299, ["PharmEasy"] = 319, ["Orange Health"] = 349, ["Apollo 24*7"] = 399
+                },
+                ["Thyroid Panel"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 649, ["PharmEasy"] = 629, ["Orange Health"] = 699, ["Apollo 24*7"] = 749
+                },
+                ["Blood Sugar Fasting"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 79, ["PharmEasy"] = 89, ["Orange Health"] = 99, ["Apollo 24*7"] = 119
+                },
+                ["Blood Sugar Postprandial"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 79, ["PharmEasy"] = 89, ["Orange Health"] = 99, ["Apollo 24*7"] = 119
+                },
+                ["HbA1c"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 349, ["PharmEasy"] = 329, ["Orange Health"] = 399, ["Apollo 24*7"] = 449
+                },
+                ["Liver Function Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 449, ["PharmEasy"] = 469, ["Orange Health"] = 499, ["Apollo 24*7"] = 549
+                },
+                ["Kidney Function Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 449, ["PharmEasy"] = 479, ["Orange Health"] = 519, ["Apollo 24*7"] = 579
+                },
+                ["Vitamin D"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 899, ["PharmEasy"] = 849, ["Orange Health"] = 949, ["Apollo 24*7"] = 1099
+                },
+                ["Vitamin B12"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 649, ["PharmEasy"] = 629, ["Orange Health"] = 699, ["Apollo 24*7"] = 799
+                },
+                ["COVID-19 RT-PCR"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 499, ["Orange Health"] = 549, ["Apollo 24*7"] = 499
+                },
+                ["Dengue NS1 Antigen"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 549, ["PharmEasy"] = 579, ["Orange Health"] = 599, ["Apollo 24*7"] = 649
+                },
+                ["Urine Routine Examination"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["Iron Studies"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 449, ["PharmEasy"] = 429, ["Orange Health"] = 499, ["Apollo 24*7"] = 549
+                },
+                ["Calcium"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 149, ["PharmEasy"] = 159, ["Orange Health"] = 179, ["Apollo 24*7"] = 199
+                },
+                ["Serum Electrolytes"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 249, ["PharmEasy"] = 269, ["Orange Health"] = 299, ["Apollo 24*7"] = 349
+                },
+                ["C-Reactive Protein"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 349, ["PharmEasy"] = 369, ["Orange Health"] = 399, ["Apollo 24*7"] = 449
+                },
+                ["ESR"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 79, ["PharmEasy"] = 89, ["Orange Health"] = 99, ["Apollo 24*7"] = 119
+                },
+                ["Uric Acid"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 149, ["PharmEasy"] = 159, ["Orange Health"] = 179, ["Apollo 24*7"] = 199
+                },
+                ["Rheumatoid Factor"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 249, ["PharmEasy"] = 269, ["Orange Health"] = 299, ["Apollo 24*7"] = 349
+                },
+                ["ANA Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 699, ["PharmEasy"] = 729, ["Orange Health"] = 799, ["Apollo 24*7"] = 899
+                },
+                ["Hepatitis B Surface Antigen"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 249, ["PharmEasy"] = 269, ["Orange Health"] = 299, ["Apollo 24*7"] = 349
+                },
+                ["Hepatitis C Antibody"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 299, ["PharmEasy"] = 319, ["Orange Health"] = 349, ["Apollo 24*7"] = 399
+                },
+                ["HIV Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 299, ["PharmEasy"] = 319, ["Orange Health"] = 349, ["Apollo 24*7"] = 399
+                },
+                ["Malaria Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 199, ["PharmEasy"] = 219, ["Orange Health"] = 249, ["Apollo 24*7"] = 299
+                },
+                ["Typhoid Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 299, ["PharmEasy"] = 319, ["Orange Health"] = 349, ["Apollo 24*7"] = 399
+                },
+                ["Widal Test"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 149, ["PharmEasy"] = 169, ["Orange Health"] = 199, ["Apollo 24*7"] = 249
+                },
+                ["Stool Routine Examination"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["Semen Analysis"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 529, ["Orange Health"] = 599, ["Apollo 24*7"] = 649
+                },
+                ["Prolactin"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 349, ["PharmEasy"] = 369, ["Orange Health"] = 399, ["Apollo 24*7"] = 449
+                },
+                ["Testosterone"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 529, ["Orange Health"] = 579, ["Apollo 24*7"] = 649
+                },
+                ["FSH"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 349, ["PharmEasy"] = 369, ["Orange Health"] = 399, ["Apollo 24*7"] = 449
+                },
+                ["LH"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 349, ["PharmEasy"] = 369, ["Orange Health"] = 399, ["Apollo 24*7"] = 449
+                },
+                ["Estradiol"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 529, ["Orange Health"] = 579, ["Apollo 24*7"] = 649
+                },
+                ["Beta HCG"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 449, ["PharmEasy"] = 479, ["Orange Health"] = 529, ["Apollo 24*7"] = 599
+                },
+                ["PSA"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 599, ["PharmEasy"] = 629, ["Orange Health"] = 699, ["Apollo 24*7"] = 799
+                },
+                ["Cortisol"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 529, ["Orange Health"] = 579, ["Apollo 24*7"] = 649
+                },
+                ["Insulin Fasting"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 449, ["PharmEasy"] = 469, ["Orange Health"] = 519, ["Apollo 24*7"] = 599
+                },
+                ["Magnesium"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 199, ["PharmEasy"] = 219, ["Orange Health"] = 249, ["Apollo 24*7"] = 299
+                },
+                ["Phosphorus"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 149, ["PharmEasy"] = 169, ["Orange Health"] = 199, ["Apollo 24*7"] = 249
+                },
+                ["Total Protein"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 149, ["PharmEasy"] = 169, ["Orange Health"] = 199, ["Apollo 24*7"] = 249
+                },
+                ["Albumin"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["Blood Culture"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 799, ["PharmEasy"] = 849, ["Orange Health"] = 899, ["Apollo 24*7"] = 999
+                },
+                ["Urine Culture"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 499, ["PharmEasy"] = 529, ["Orange Health"] = 579, ["Apollo 24*7"] = 649
+                },
+                ["Throat Swab Culture"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 549, ["PharmEasy"] = 579, ["Orange Health"] = 629, ["Apollo 24*7"] = 699
+                },
+                ["Pap Smear"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 599, ["PharmEasy"] = 629, ["Orange Health"] = 699, ["Apollo 24*7"] = 799
+                },
+                ["Creatinine"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["Blood Urea Nitrogen"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["Bilirubin Total"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["SGPT ALT"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+                ["SGOT AST"] = new Dictionary<string, decimal>
+                {
+                    ["Tata 1mg"] = 99, ["PharmEasy"] = 109, ["Orange Health"] = 129, ["Apollo 24*7"] = 149
+                },
+            };
+
+        // City-based price multipliers
+        public static readonly Dictionary<string, decimal> CityMultipliers =
+            new Dictionary<string, decimal>
+            {
+                ["mumbai"] = 1.10m,
+                ["delhi"] = 1.08m,
+                ["new delhi"] = 1.08m,
+                ["bangalore"] = 1.05m,
+                ["bengaluru"] = 1.05m,
+                ["hyderabad"] = 1.00m,
+                ["chennai"] = 1.02m,
+                ["kolkata"] = 1.03m,
+                ["pune"] = 1.04m,
+                ["ahmedabad"] = 1.00m,
+                ["jaipur"] = 0.97m,
+                ["lucknow"] = 0.96m,
+                ["bhopal"] = 0.95m,
+                ["indore"] = 0.95m,
+                ["nagpur"] = 0.96m,
+                ["surat"] = 0.97m,
+                ["coimbatore"] = 0.96m,
+                ["kochi"] = 0.98m,
+                ["chandigarh"] = 0.97m,
+                ["gurgaon"] = 1.06m,
+                ["gurugram"] = 1.06m,
+                ["noida"] = 1.05m,
+            };
+
+        // Test aliases for fuzzy matching
+        public static readonly Dictionary<string, List<string>> TestAliases =
+            new Dictionary<string, List<string>>
+            {
+                ["Complete Blood Count"] = new List<string> { "cbc", "complete blood count", "blood count", "hemogram", "full blood count", "fbc" },
+                ["Lipid Profile"] = new List<string> { "lipid", "lipid profile", "cholesterol", "lipid panel", "cholesterol test" },
+                ["Thyroid Stimulating Hormone"] = new List<string> { "tsh", "thyroid stimulating hormone", "thyroid test" },
+                ["Thyroid Panel"] = new List<string> { "thyroid panel", "thyroid profile", "t3 t4 tsh", "thyroid function" },
+                ["Blood Sugar Fasting"] = new List<string> { "fasting blood sugar", "fbs", "blood glucose fasting", "fasting glucose" },
+                ["Blood Sugar Postprandial"] = new List<string> { "pp blood sugar", "ppbs", "postprandial glucose", "blood sugar pp", "2 hour glucose" },
+                ["HbA1c"] = new List<string> { "hba1c", "glycated hemoglobin", "a1c", "glycohemoglobin", "hb a1c" },
+                ["Liver Function Test"] = new List<string> { "lft", "liver function", "liver panel", "liver test", "hepatic function" },
+                ["Kidney Function Test"] = new List<string> { "kft", "kidney function", "renal function", "kidney test", "rft", "renal profile" },
+                ["Vitamin D"] = new List<string> { "vitamin d", "vit d", "25-oh vitamin d", "vitamin d3", "25 hydroxyvitamin d" },
+                ["Vitamin B12"] = new List<string> { "vitamin b12", "vit b12", "cobalamin", "b12", "cyanocobalamin" },
+                ["COVID-19 RT-PCR"] = new List<string> { "covid", "covid-19", "coronavirus", "rt-pcr", "rtpcr", "covid pcr", "sars-cov-2" },
+                ["Dengue NS1 Antigen"] = new List<string> { "dengue", "dengue ns1", "dengue antigen", "ns1 antigen" },
+                ["Urine Routine Examination"] = new List<string> { "urine test", "urine routine", "urinalysis", "urine analysis", "ure", "urine re" },
+                ["Iron Studies"] = new List<string> { "iron", "iron studies", "serum iron", "iron panel", "iron profile" },
+                ["Calcium"] = new List<string> { "calcium", "serum calcium", "ca" },
+                ["Serum Electrolytes"] = new List<string> { "electrolytes", "serum electrolytes", "na k cl", "sodium potassium" },
+                ["C-Reactive Protein"] = new List<string> { "crp", "c-reactive protein", "c reactive protein" },
+                ["ESR"] = new List<string> { "esr", "erythrocyte sedimentation rate", "sedimentation rate" },
+                ["Uric Acid"] = new List<string> { "uric acid", "gout test", "serum uric acid" },
+                ["Rheumatoid Factor"] = new List<string> { "rf", "rheumatoid factor", "ra factor", "rheumatoid arthritis test" },
+                ["ANA Test"] = new List<string> { "ana", "antinuclear antibody", "ana test" },
+                ["Hepatitis B Surface Antigen"] = new List<string> { "hbsag", "hepatitis b", "hbs ag", "hepatitis b surface antigen" },
+                ["Hepatitis C Antibody"] = new List<string> { "hcv", "hepatitis c", "anti-hcv", "hepatitis c antibody" },
+                ["HIV Test"] = new List<string> { "hiv", "hiv test", "aids test", "anti-hiv" },
+                ["Malaria Test"] = new List<string> { "malaria", "malaria test", "malaria antigen" },
+                ["Typhoid Test"] = new List<string> { "typhoid", "typhoid test", "salmonella" },
+                ["Widal Test"] = new List<string> { "widal", "widal test" },
+                ["Stool Routine Examination"] = new List<string> { "stool test", "stool routine", "stool analysis", "feces test" },
+                ["Semen Analysis"] = new List<string> { "semen analysis", "sperm test", "semen test", "sperm count" },
+                ["Prolactin"] = new List<string> { "prolactin", "prl" },
+                ["Testosterone"] = new List<string> { "testosterone", "total testosterone", "serum testosterone" },
+                ["FSH"] = new List<string> { "fsh", "follicle stimulating hormone" },
+                ["LH"] = new List<string> { "lh", "luteinizing hormone", "luteinising hormone" },
+                ["Estradiol"] = new List<string> { "estradiol", "oestradiol", "e2" },
+                ["Beta HCG"] = new List<string> { "beta hcg", "bhcg", "pregnancy test", "hcg test", "beta human chorionic gonadotropin" },
+                ["PSA"] = new List<string> { "psa", "prostate specific antigen", "prostate test" },
+                ["Cortisol"] = new List<string> { "cortisol", "serum cortisol" },
+                ["Insulin Fasting"] = new List<string> { "insulin", "fasting insulin", "serum insulin" },
+                ["Magnesium"] = new List<string> { "magnesium", "serum magnesium", "mg" },
+                ["Phosphorus"] = new List<string> { "phosphorus", "phosphate", "serum phosphorus" },
+                ["Total Protein"] = new List<string> { "total protein", "serum protein", "protein test" },
+                ["Albumin"] = new List<string> { "albumin", "serum albumin" },
+                ["Blood Culture"] = new List<string> { "blood culture", "blood culture sensitivity" },
+                ["Urine Culture"] = new List<string> { "urine culture", "urine c/s", "urine culture sensitivity" },
+                ["Throat Swab Culture"] = new List<string> { "throat swab", "throat culture" },
+                ["Pap Smear"] = new List<string> { "pap smear", "pap test", "cervical smear", "papanicolaou" },
+                ["Creatinine"] = new List<string> { "creatinine", "serum creatinine" },
+                ["Blood Urea Nitrogen"] = new List<string> { "bun", "blood urea", "blood urea nitrogen", "urea" },
+                ["Bilirubin Total"] = new List<string> { "bilirubin", "total bilirubin", "serum bilirubin" },
+                ["SGPT ALT"] = new List<string> { "sgpt", "alt", "alanine aminotransferase" },
+                ["SGOT AST"] = new List<string> { "sgot", "ast", "aspartate aminotransferase" },
+            };
+
+        public static decimal GetCityMultiplier(string city)
+        {
+            if (string.IsNullOrWhiteSpace(city)) return 1.0m;
+            var key = city.Trim().ToLower();
+            return CityMultipliers.TryGetValue(key, out var multiplier) ? multiplier : 0.95m;
+        }
+
+        public static string ResolveTestName(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return null;
+            var lower = input.Trim().ToLower();
+
+            foreach (var alias in TestAliases)
+            {
+                if (alias.Value.Any(a => a.Contains(lower) || lower.Contains(a)))
+                    return alias.Key;
+            }
+
+            // Exact canonical name match
+            foreach (var test in BasePrices.Keys)
+            {
+                if (test.ToLower().Contains(lower) || lower.Contains(test.ToLower()))
+                    return test;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/Providers/Apollo247PriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/Providers/Apollo247PriceProvider.cs
@@ -1,0 +1,8 @@
+namespace TailSpin.SpaceGame.Web.Services.Providers
+{
+    public class Apollo247PriceProvider : BaseLabTestPriceProvider
+    {
+        public override string ProviderName => "Apollo 24*7";
+        protected override string BookingBaseUrl => "https://www.apollo247.com/lab-tests/search?searchQuery=";
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/Providers/BaseLabTestPriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/Providers/BaseLabTestPriceProvider.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TailSpin.SpaceGame.Web.Models.MedicalTest;
+
+namespace TailSpin.SpaceGame.Web.Services.Providers
+{
+    public abstract class BaseLabTestPriceProvider : ILabTestPriceProvider
+    {
+        public abstract string ProviderName { get; }
+        protected abstract string BookingBaseUrl { get; }
+
+        public Task<List<TestPriceResult>> GetPricesAsync(List<string> testNames, string location)
+        {
+            var results = new List<TestPriceResult>();
+            var cityMultiplier = MockPriceData.GetCityMultiplier(location);
+
+            foreach (var inputName in testNames)
+            {
+                var canonicalName = MockPriceData.ResolveTestName(inputName);
+
+                if (canonicalName == null ||
+                    !MockPriceData.BasePrices.TryGetValue(canonicalName, out var providerPrices) ||
+                    !providerPrices.TryGetValue(ProviderName, out var basePrice))
+                {
+                    results.Add(new TestPriceResult
+                    {
+                        TestName = inputName,
+                        ProviderName = ProviderName,
+                        IsAvailable = false,
+                        Price = 0,
+                        BookingUrl = "#"
+                    });
+                    continue;
+                }
+
+                var finalPrice = decimal.Round(basePrice * cityMultiplier, 0);
+
+                results.Add(new TestPriceResult
+                {
+                    TestName = canonicalName,
+                    ProviderName = ProviderName,
+                    IsAvailable = true,
+                    Price = finalPrice,
+                    BookingUrl = $"{BookingBaseUrl}{System.Uri.EscapeDataString(canonicalName)}"
+                });
+            }
+
+            return Task.FromResult(results);
+        }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/Providers/OrangeHealthPriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/Providers/OrangeHealthPriceProvider.cs
@@ -1,0 +1,8 @@
+namespace TailSpin.SpaceGame.Web.Services.Providers
+{
+    public class OrangeHealthPriceProvider : BaseLabTestPriceProvider
+    {
+        public override string ProviderName => "Orange Health";
+        protected override string BookingBaseUrl => "https://www.orangehealth.in/search?q=";
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/Providers/PharmEasyPriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/Providers/PharmEasyPriceProvider.cs
@@ -1,0 +1,8 @@
+namespace TailSpin.SpaceGame.Web.Services.Providers
+{
+    public class PharmEasyPriceProvider : BaseLabTestPriceProvider
+    {
+        public override string ProviderName => "PharmEasy";
+        protected override string BookingBaseUrl => "https://pharmeasy.in/online-medicine-order/search?name=";
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/Providers/Tata1mgPriceProvider.cs
+++ b/Tailspin.SpaceGame.Web/Services/Providers/Tata1mgPriceProvider.cs
@@ -1,0 +1,8 @@
+namespace TailSpin.SpaceGame.Web.Services.Providers
+{
+    public class Tata1mgPriceProvider : BaseLabTestPriceProvider
+    {
+        public override string ProviderName => "Tata 1mg";
+        protected override string BookingBaseUrl => "https://www.1mg.com/lab-tests/search?name=";
+    }
+}

--- a/Tailspin.SpaceGame.Web/Services/TestPriceComparisonService.cs
+++ b/Tailspin.SpaceGame.Web/Services/TestPriceComparisonService.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TailSpin.SpaceGame.Web.Models.MedicalTest;
+
+namespace TailSpin.SpaceGame.Web.Services
+{
+    public class TestPriceComparisonService
+    {
+        private readonly IEnumerable<ILabTestPriceProvider> _providers;
+
+        public TestPriceComparisonService(IEnumerable<ILabTestPriceProvider> providers)
+        {
+            _providers = providers;
+        }
+
+        public async Task<ComparisonViewModel> CompareAsync(TestSearchQuery query)
+        {
+            var providerList = _providers.ToList();
+            var providerNames = providerList.Select(p => p.ProviderName).ToList();
+
+            // Fetch prices from all providers concurrently
+            var allProviderResults = await Task.WhenAll(
+                providerList.Select(p => p.GetPricesAsync(query.ParsedTestNames, query.Location))
+            );
+
+            // Build comparison rows grouped by canonical test name
+            // Use the resolved canonical name from the first available result per input
+            var testRows = new List<TestComparisonRow>();
+            var resolvedNames = new Dictionary<string, string>(); // inputName -> canonicalName
+
+            // Collect all unique canonical test names returned
+            foreach (var providerResults in allProviderResults)
+            {
+                foreach (var result in providerResults.Where(r => r.IsAvailable))
+                {
+                    if (!resolvedNames.ContainsValue(result.TestName))
+                    {
+                        // Find the original input that resolved to this canonical name
+                        var original = query.ParsedTestNames.FirstOrDefault(
+                            t => MockPriceData.ResolveTestName(t) == result.TestName);
+                        if (original != null && !resolvedNames.ContainsKey(original))
+                            resolvedNames[original] = result.TestName;
+                    }
+                }
+            }
+
+            // For inputs that couldn't be resolved, keep the original
+            foreach (var input in query.ParsedTestNames)
+            {
+                if (!resolvedNames.ContainsKey(input))
+                    resolvedNames[input] = input;
+            }
+
+            // Build one row per input test
+            foreach (var input in query.ParsedTestNames)
+            {
+                var canonicalName = resolvedNames.TryGetValue(input, out var name) ? name : input;
+
+                var row = new TestComparisonRow
+                {
+                    TestName = canonicalName,
+                    ProviderPrices = new List<TestPriceResult>()
+                };
+
+                // Add one price result per provider (preserving provider order)
+                for (int i = 0; i < providerList.Count; i++)
+                {
+                    var providerResults = allProviderResults[i];
+                    var result = providerResults.FirstOrDefault(r =>
+                        r.TestName == canonicalName || r.TestName == input);
+
+                    if (result != null)
+                    {
+                        row.ProviderPrices.Add(result);
+                    }
+                    else
+                    {
+                        row.ProviderPrices.Add(new TestPriceResult
+                        {
+                            TestName = canonicalName,
+                            ProviderName = providerList[i].ProviderName,
+                            IsAvailable = false,
+                            Price = 0,
+                            BookingUrl = "#"
+                        });
+                    }
+                }
+
+                testRows.Add(row);
+            }
+
+            return new ComparisonViewModel
+            {
+                Query = query,
+                Results = testRows,
+                ProviderNames = providerNames
+            };
+        }
+    }
+}

--- a/Tailspin.SpaceGame.Web/Startup.cs
+++ b/Tailspin.SpaceGame.Web/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TailSpin.SpaceGame.Web.Models;
+using TailSpin.SpaceGame.Web.Services;
+using TailSpin.SpaceGame.Web.Services.Providers;
 using Microsoft.AspNetCore.Http;
 
 
@@ -37,6 +39,13 @@ namespace TailSpin.SpaceGame.Web
             // Add document stores. These are passed to the HomeController constructor.
             services.AddSingleton<IDocumentDBRepository<Score>>(new LocalDocumentDBRepository<Score>(@"SampleData/scores.json"));
             services.AddSingleton<IDocumentDBRepository<Profile>>(new LocalDocumentDBRepository<Profile>(@"SampleData/profiles.json"));
+
+            // Medical test price comparison services
+            services.AddSingleton<ILabTestPriceProvider, Tata1mgPriceProvider>();
+            services.AddSingleton<ILabTestPriceProvider, PharmEasyPriceProvider>();
+            services.AddSingleton<ILabTestPriceProvider, OrangeHealthPriceProvider>();
+            services.AddSingleton<ILabTestPriceProvider, Apollo247PriceProvider>();
+            services.AddSingleton<TestPriceComparisonService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Tailspin.SpaceGame.Web/Views/MedicalTest/Index.cshtml
+++ b/Tailspin.SpaceGame.Web/Views/MedicalTest/Index.cshtml
@@ -1,0 +1,193 @@
+@model TailSpin.SpaceGame.Web.Models.MedicalTest.TestSearchQuery
+@{
+    ViewData["Title"] = "Medical Test Price Comparison";
+
+    var popularTests = new[]
+    {
+        "Complete Blood Count", "Lipid Profile", "Thyroid Panel",
+        "HbA1c", "Liver Function Test", "Kidney Function Test",
+        "Vitamin D", "Vitamin B12", "Blood Sugar Fasting", "Dengue NS1 Antigen"
+    };
+
+    var indianCities = new[]
+    {
+        "Mumbai", "Delhi", "Bangalore", "Hyderabad", "Chennai",
+        "Kolkata", "Pune", "Ahmedabad", "Jaipur", "Lucknow",
+        "Gurgaon", "Noida", "Coimbatore", "Kochi", "Chandigarh"
+    };
+}
+
+<section class="medical-hero">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 col-md-offset-2 text-center">
+                <div class="medical-icon" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="80" height="80">
+                        <circle cx="32" cy="32" r="30" fill="#e8f5e9" stroke="#43a047" stroke-width="2"/>
+                        <rect x="28" y="14" width="8" height="36" rx="3" fill="#43a047"/>
+                        <rect x="14" y="28" width="36" height="8" rx="3" fill="#43a047"/>
+                    </svg>
+                </div>
+                <h1 class="medical-title">Medical Test Price Comparison</h1>
+                <p class="medical-subtitle">
+                    Compare prices for medical tests across <strong>Tata 1mg</strong>,
+                    <strong>PharmEasy</strong>, <strong>Orange Health</strong>, and
+                    <strong>Apollo 24*7</strong> — and find the cheapest option near you.
+                </p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="medical-search">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 col-md-offset-2">
+                <div class="panel panel-default medical-panel">
+                    <div class="panel-body">
+                        <form asp-controller="MedicalTest" asp-action="Compare" method="post">
+                            @Html.AntiForgeryToken()
+
+                            <div class="form-group @(ViewData.ModelState["TestNames"]?.Errors.Count > 0 ? "has-error" : "")">
+                                <label for="TestNames" class="control-label medical-label">
+                                    Medical Tests
+                                    <small class="text-muted">(comma-separated)</small>
+                                </label>
+                                <textarea id="TestNames"
+                                          name="TestNames"
+                                          class="form-control medical-textarea"
+                                          rows="3"
+                                          placeholder="e.g. CBC, Lipid Profile, Vitamin D">@Model?.TestNames</textarea>
+                                @if (ViewData.ModelState["TestNames"]?.Errors.Count > 0)
+                                {
+                                    <span class="help-block">@ViewData.ModelState["TestNames"].Errors[0].ErrorMessage</span>
+                                }
+                            </div>
+
+                            <div class="form-group @(ViewData.ModelState["Location"]?.Errors.Count > 0 ? "has-error" : "")">
+                                <label for="Location" class="control-label medical-label">Your City</label>
+                                <input type="text"
+                                       id="Location"
+                                       name="Location"
+                                       class="form-control"
+                                       list="cityList"
+                                       placeholder="e.g. Mumbai, Delhi, Bangalore"
+                                       value="@Model?.Location" />
+                                <datalist id="cityList">
+                                    @foreach (var city in indianCities)
+                                    {
+                                        <option value="@city" />
+                                    }
+                                </datalist>
+                                @if (ViewData.ModelState["Location"]?.Errors.Count > 0)
+                                {
+                                    <span class="help-block">@ViewData.ModelState["Location"].Errors[0].ErrorMessage</span>
+                                }
+                            </div>
+
+                            <button type="submit" class="btn btn-primary btn-lg btn-block medical-btn">
+                                Compare Prices
+                            </button>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="popular-tests">
+                    <p class="popular-label">Popular tests — click to add:</p>
+                    <div class="test-chips">
+                        @foreach (var test in popularTests)
+                        {
+                            <button type="button"
+                                    class="btn btn-default btn-xs test-chip"
+                                    onclick="addTest('@test')">@test</button>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row medical-providers-row">
+            <div class="col-md-8 col-md-offset-2">
+                <h4 class="text-center providers-title">Providers We Compare</h4>
+                <div class="row">
+                    <div class="col-xs-6 col-sm-3 text-center provider-card">
+                        <div class="provider-badge" style="background:#e53935;">1mg</div>
+                        <p>Tata 1mg</p>
+                    </div>
+                    <div class="col-xs-6 col-sm-3 text-center provider-card">
+                        <div class="provider-badge" style="background:#8e24aa;">PE</div>
+                        <p>PharmEasy</p>
+                    </div>
+                    <div class="col-xs-6 col-sm-3 text-center provider-card">
+                        <div class="provider-badge" style="background:#e65100;">OH</div>
+                        <p>Orange Health</p>
+                    </div>
+                    <div class="col-xs-6 col-sm-3 text-center provider-card">
+                        <div class="provider-badge" style="background:#1565c0;">A247</div>
+                        <p>Apollo 24*7</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+<script>
+    function addTest(testName) {
+        var textarea = document.getElementById('TestNames');
+        var current = textarea.value.trim();
+        if (current === '') {
+            textarea.value = testName;
+        } else {
+            // Avoid duplicates
+            var existing = current.split(',').map(function(t) { return t.trim().toLowerCase(); });
+            if (existing.indexOf(testName.toLowerCase()) === -1) {
+                textarea.value = current + ', ' + testName;
+            }
+        }
+        textarea.focus();
+    }
+</script>
+<style>
+    .medical-hero {
+        background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
+        padding: 60px 0 40px;
+        border-bottom: 1px solid #c8e6c9;
+    }
+    .medical-icon { margin-bottom: 20px; }
+    .medical-title {
+        font-size: 2.2em;
+        color: #2e7d32;
+        margin-bottom: 12px;
+    }
+    .medical-subtitle {
+        font-size: 1.1em;
+        color: #555;
+        max-width: 560px;
+        margin: 0 auto;
+    }
+    .medical-search { padding: 40px 0; }
+    .medical-panel { border-radius: 8px; box-shadow: 0 2px 12px rgba(0,0,0,0.08); border: none; }
+    .medical-panel .panel-body { padding: 30px; }
+    .medical-label { font-size: 1em; font-weight: 600; color: #333; }
+    .medical-textarea { resize: vertical; min-height: 80px; }
+    .medical-btn { background: #2e7d32; border-color: #1b5e20; font-size: 1.1em; margin-top: 8px; }
+    .medical-btn:hover { background: #1b5e20; }
+    .popular-tests { margin-top: 20px; }
+    .popular-label { color: #777; font-size: 0.9em; margin-bottom: 8px; }
+    .test-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+    .test-chip { border-radius: 20px; padding: 4px 12px; cursor: pointer; transition: all 0.2s; }
+    .test-chip:hover { background: #e8f5e9; border-color: #43a047; color: #2e7d32; }
+    .medical-providers-row { margin-top: 40px; }
+    .providers-title { color: #777; font-size: 0.95em; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 20px; }
+    .provider-card { margin-bottom: 15px; }
+    .provider-badge {
+        width: 56px; height: 56px; border-radius: 12px;
+        color: #fff; font-weight: 700; font-size: 1em;
+        display: flex; align-items: center; justify-content: center;
+        margin: 0 auto 8px;
+    }
+    .provider-card p { font-size: 0.85em; color: #555; margin: 0; }
+</style>
+}

--- a/Tailspin.SpaceGame.Web/Views/MedicalTest/Results.cshtml
+++ b/Tailspin.SpaceGame.Web/Views/MedicalTest/Results.cshtml
@@ -1,0 +1,211 @@
+@model TailSpin.SpaceGame.Web.Models.MedicalTest.ComparisonViewModel
+@{
+    ViewData["Title"] = "Price Comparison Results";
+}
+
+<section class="results-header">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8">
+                <h2 class="results-title">
+                    Price Comparison Results
+                </h2>
+                <p class="results-subtitle">
+                    @Model.Results.Count test(s) compared in
+                    <strong>@Model.Query.Location</strong>
+                </p>
+            </div>
+            <div class="col-md-4 text-right">
+                <a asp-controller="MedicalTest" asp-action="Index" class="btn btn-default btn-search-again">
+                    Search Again
+                </a>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="results-body">
+    <div class="container">
+
+        @if (!Model.HasResults)
+        {
+            <div class="alert alert-warning text-center">
+                <strong>No results found.</strong>
+                Please check your test names and try again.
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive medical-table-wrap">
+                <table class="table table-bordered medical-table">
+                    <thead>
+                        <tr class="table-header-row">
+                            <th class="test-name-col">Test Name</th>
+                            @foreach (var provider in Model.ProviderNames)
+                            {
+                                <th class="provider-col text-center">@provider</th>
+                            }
+                            <th class="cheapest-col text-center">Cheapest</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var row in Model.Results)
+                        {
+                            var cheapest = row.CheapestProvider;
+                            <tr>
+                                <td class="test-name-cell">
+                                    <strong>@row.TestName</strong>
+                                </td>
+                                @foreach (var price in row.ProviderPrices)
+                                {
+                                    var isCheapest = cheapest != null
+                                        && price.IsAvailable
+                                        && price.ProviderName == cheapest.ProviderName
+                                        && price.Price == cheapest.Price;
+
+                                    <td class="price-cell text-center @(isCheapest ? "cheapest-cell" : "") @(!price.IsAvailable ? "unavailable-cell" : "")">
+                                        @if (price.IsAvailable)
+                                        {
+                                            <span class="price-amount">&#x20B9;@price.Price.ToString("N0")</span>
+                                            @if (isCheapest)
+                                            {
+                                                <br /><span class="cheapest-badge">CHEAPEST</span>
+                                            }
+                                            <br />
+                                            <a href="@price.BookingUrl" target="_blank" rel="noopener" class="book-link">Book</a>
+                                        }
+                                        else
+                                        {
+                                            <span class="unavailable-text">Not Available</span>
+                                        }
+                                    </td>
+                                }
+                                <td class="cheapest-summary-cell text-center">
+                                    @if (cheapest != null)
+                                    {
+                                        <div class="cheapest-summary">
+                                            <span class="cheapest-provider-name">@cheapest.ProviderName</span>
+                                            <br />
+                                            <span class="cheapest-price">&#x20B9;@cheapest.Price.ToString("N0")</span>
+                                        </div>
+                                    }
+                                    else
+                                    {
+                                        <span class="unavailable-text">N/A</span>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+
+            @if (Model.TotalSavings > 0)
+            {
+                <div class="savings-banner">
+                    <span class="savings-icon" aria-hidden="true">&#x1F4B0;</span>
+                    You can save up to
+                    <strong>&#x20B9;@Model.TotalSavings.ToString("N0")</strong>
+                    by always choosing the cheapest provider!
+                </div>
+            }
+
+            <div class="disclaimer">
+                <small class="text-muted">
+                    * Prices shown are indicative and may vary. Actual prices depend on
+                    promotions, lab partner availability, and home collection charges.
+                    Always verify on the provider's website before booking.
+                </small>
+            </div>
+
+            <div class="search-again-bottom text-center">
+                <a asp-controller="MedicalTest" asp-action="Index" class="btn btn-primary">
+                    Compare More Tests
+                </a>
+            </div>
+        }
+
+    </div>
+</section>
+
+@section Scripts {
+<style>
+    .results-header {
+        background: linear-gradient(135deg, #e8f5e9 0%, #f1f8e9 100%);
+        padding: 30px 0;
+        border-bottom: 1px solid #c8e6c9;
+        margin-bottom: 30px;
+    }
+    .results-title { color: #2e7d32; margin: 0 0 6px; }
+    .results-subtitle { color: #555; margin: 0; }
+    .btn-search-again { margin-top: 8px; }
+
+    .results-body { padding-bottom: 50px; }
+
+    .medical-table-wrap { margin-bottom: 20px; }
+    .medical-table { border-collapse: separate; border-spacing: 0; }
+    .medical-table thead th {
+        background: #2e7d32;
+        color: #fff;
+        font-size: 0.9em;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        padding: 12px 10px;
+        vertical-align: middle;
+    }
+    .test-name-col { width: 22%; min-width: 140px; }
+    .provider-col { width: 17%; }
+    .cheapest-col { width: 13%; background: #1b5e20 !important; }
+
+    .medical-table tbody td { padding: 14px 10px; vertical-align: middle; }
+    .test-name-cell { font-size: 0.95em; }
+
+    .price-cell { font-size: 0.95em; }
+    .price-amount { font-size: 1.1em; font-weight: 600; color: #333; }
+
+    .cheapest-cell {
+        background: #e8f5e9 !important;
+        border: 2px solid #43a047 !important;
+    }
+    .cheapest-badge {
+        display: inline-block;
+        background: #43a047;
+        color: #fff;
+        font-size: 0.65em;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        padding: 1px 6px;
+        border-radius: 3px;
+        margin-top: 2px;
+    }
+    .book-link {
+        font-size: 0.78em;
+        color: #1565c0;
+        text-decoration: underline;
+    }
+
+    .unavailable-cell { background: #fafafa !important; }
+    .unavailable-text { color: #bbb; font-size: 0.85em; }
+
+    .cheapest-summary-cell { background: #f9fbe7; font-size: 0.9em; }
+    .cheapest-provider-name { font-weight: 600; color: #2e7d32; font-size: 0.85em; }
+    .cheapest-price { font-size: 1.15em; font-weight: 700; color: #2e7d32; }
+
+    .savings-banner {
+        background: #fff9c4;
+        border: 1px solid #f9a825;
+        border-radius: 6px;
+        padding: 14px 20px;
+        text-align: center;
+        font-size: 1.05em;
+        color: #555;
+        margin-bottom: 16px;
+    }
+    .savings-icon { font-size: 1.2em; margin-right: 6px; }
+
+    .disclaimer { margin-bottom: 24px; }
+    .search-again-bottom { margin-top: 10px; }
+    .search-again-bottom .btn { background: #2e7d32; border-color: #1b5e20; }
+    .search-again-bottom .btn:hover { background: #1b5e20; }
+</style>
+}

--- a/Tailspin.SpaceGame.Web/Views/Shared/_Layout.cshtml
+++ b/Tailspin.SpaceGame.Web/Views/Shared/_Layout.cshtml
@@ -19,6 +19,26 @@
     <body>
         <partial name="_CookieConsentPartial" />
 
+        <nav class="navbar navbar-default navbar-static-top site-nav">
+            <div class="container">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#site-nav-collapse">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <a class="navbar-brand" asp-controller="Home" asp-action="Index">TailSpin SpaceGame</a>
+                </div>
+                <div class="collapse navbar-collapse" id="site-nav-collapse">
+                    <ul class="nav navbar-nav">
+                        <li><a asp-controller="Home" asp-action="Index">Leaderboard</a></li>
+                        <li><a asp-controller="MedicalTest" asp-action="Index">&#x1F3E5; Test Price Compare</a></li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+
         <div class="container-fluid body-content">
             <div class="row">
                 @RenderBody()


### PR DESCRIPTION
Implements a Medical Test Price Comparison module allowing users to enter
one or more medical test names and a city in India, then compare prices
across Tata 1mg, PharmEasy, Orange Health, and Apollo 24*7. Uses a
realistic mock data service with 50+ common tests and city-based price
multipliers. Architecture uses ILabTestPriceProvider interface for future
real API/scraping integration.

https://claude.ai/code/session_01VSxUtDZhFMUWnKGFwA48As